### PR TITLE
[FIX] Update mob rendering to include unique_name and adjust offset in MobInfo

### DIFF
--- a/gui/src/utils/rendering.tsx
+++ b/gui/src/utils/rendering.tsx
@@ -262,15 +262,19 @@ class RadarRendering {
         // this.renderDistance(ctx, canvas, radarPosition, resource.location, this.ResourceSize, rX, rY);
     }
 
-    static renderMob(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, radarPosition: any, mob: { mob_type: string; health: { value: number; max: number }; avatar?: string; enchant?: number; harvestable_type?: string; location: { x: number; y: number }; tier?: number, aggroradius: string }, zoom: number, displayedSettings: any ) {
+    static renderMob(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement, radarPosition: any, mob: { mob_type: string; health: { value: number; max: number }; unique_name?: string; avatar?: string; enchant?: number; harvestable_type?: string; location: { x: number; y: number }; tier?: number, aggroradius: string }, zoom: number, displayedSettings: any ) {
         if (!displayedSettings.object_types.includes('MOBS')) {
             return;
         }
 
         let renderResource = false
+        const rX =  this.getRelativePositionX(radarPosition, mob.location, zoom);
+        const rY =  this.getRelativePositionY(radarPosition, mob.location, zoom);
 
         if (mob.mob_type === 'HARVESTABLE' && displayedSettings.object_types.includes('RESOURCE')) {
             renderResource = true;
+            // const mobName = `${mob.unique_name} (${mob.mob_type})`;
+            // this.renderValue(ctx, canvas, this.ResourceSize, rX, rY, mobName);
             
             /* Check if resource is displayed */
             const settings = mob.harvestable_type ? displayedSettings.resources[mob.harvestable_type].find(
@@ -283,8 +287,7 @@ class RadarRendering {
             }
         }
 
-        const rX =  this.getRelativePositionX(radarPosition, mob.location, zoom);
-        const rY =  this.getRelativePositionY(radarPosition, mob.location, zoom);
+        
         
         if(renderResource){
             /* Render Iteam */
@@ -295,6 +298,7 @@ class RadarRendering {
             };
         } else {
             const mobHp = `${mob.health.value} / ${mob.health.max}`;
+            
             
 
             if(mob.avatar && mob.mob_type !== 'HARVESTABLE'){

--- a/src/albibong/classes/object_into/mob_info.py
+++ b/src/albibong/classes/object_into/mob_info.py
@@ -10,7 +10,7 @@ with open(jonPath) as json_file:
 
 
 class MobInfo:
-    offset = 14
+    offset = 15
     @classmethod
     def get_mob_id(cls, code: int):
         try:


### PR DESCRIPTION
This pull request includes updates to the radar rendering logic in `gui/src/utils/rendering.tsx` and adjustments to the `MobInfo` class in `src/albibong/classes/object_into/mob_info.py`. The changes improve rendering functionality and update a key offset value.

### Radar Rendering Updates:
* [`gui/src/utils/rendering.tsx`](diffhunk://#diff-570d12a6254afc500b0222d2e3b2efbc2e1af920cf1a493120fe1e06e47fc834L265-R277): Added `unique_name` as an optional property to the `mob` object type, enabling more detailed mob identification. Adjusted rendering logic to include relative position calculations (`rX` and `rY`) earlier in the method for better organization.
* [`gui/src/utils/rendering.tsx`](diffhunk://#diff-570d12a6254afc500b0222d2e3b2efbc2e1af920cf1a493120fe1e06e47fc834L286-R290): Removed redundant calculations of `rX` and `rY` within the `renderMob` method, streamlining the code.
* [`gui/src/utils/rendering.tsx`](diffhunk://#diff-570d12a6254afc500b0222d2e3b2efbc2e1af920cf1a493120fe1e06e47fc834R303): Added a conditional check to ensure `mob.avatar` is rendered only when the mob type is not `HARVESTABLE`.

### MobInfo Class Adjustment:
* [`src/albibong/classes/object_into/mob_info.py`](diffhunk://#diff-37836464a3d3951b7a554fe01fa7bce3865084daac6cfb6bdbc4c46043232a15L13-R13): Updated the `offset` value from `14` to `15`, likely to align with changes in mob data structure or encoding.